### PR TITLE
Fix incorrect linked in link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -102,7 +102,7 @@ author:
   instagram        :
   impactstory      : #"https://profiles.impactstory.org/u/xxxx-xxxx-xxxx-xxxx"
   lastfm           :
-  linkedin         : "https://www.linkedin.com/in/john-giorgi/"
+  linkedin         : "john-giorgi"
   orcid            : "https://orcid.org/0000-0001-9621-5046"
   pinterest        :
   soundcloud       :


### PR DESCRIPTION
Fix incorrect LinkedIn link. I gave the whole URL when this template only expected the username.